### PR TITLE
feat: added ToLiss A330neo ND overlay config

### DIFF
--- a/data/ND_overlays.cfg
+++ b/data/ND_overlays.cfg
@@ -264,6 +264,42 @@ bgalpha	0.3
 nd	x 511	y 1615	w 512	h 512 #Captain
 nd	x 511	y 1101	w 512	h 512 #Co Pilot
 
+# X-Plane 12 Toliss A339 Hi Definition
+icao    A339
+studio    ToLiss
+acf A330-900.acf
+fontsz    35
+bgalpha    0.3
+nd    x 511    y 1615    w 512    h 512 #Captain
+nd    x 511    y 1101    w 512    h 512 #Co Pilot
+
+# X-Plane 12 Toliss A339 Std Definition
+icao    A339
+studio    ToLiss
+acf A330-900_StdDef.acf
+fontsz    35
+bgalpha    0.3
+nd    x 511    y 1615    w 512    h 512 #Captain
+nd    x 511    y 1101    w 512    h 512 #Co Pilot
+
+# X-Plane 12 Toliss A340 Hi Definition
+icao	A346
+studio	ToLiss
+acf A340-600.acf
+fontsz	35
+bgalpha	0.3
+nd	x 511	y 1615	w 512	h 512 #Captain
+nd	x 511	y 1101	w 512	h 512 #Co Pilot
+
+# X-Plane 12 Toliss A340 Std Definition
+icao	A346
+studio	ToLiss
+acf A340-600_StdDef.acf
+fontsz	35
+bgalpha	0.3
+nd	x 511	y 1615	w 512	h 512 #Captain
+nd	x 511	y 1101	w 512	h 512 #Co Pilot
+
 #################################################
 #		       tolis xplane 11 		     		#
 #################################################
@@ -322,6 +358,24 @@ bgalpha	0.3
 nd	x 511	y 1615	w 512	h 512 #Captain
 nd	x 511	y 1101	w 512	h 512 #Co Pilot
 
+# X-Plane 11 Toliss A339 Hi Definition
+icao    A339
+studio    ToLiss
+acf A330-900_XP11.acf
+fontsz    35
+bgalpha    0.3
+nd    x 511    y 1615    w 512    h 512 #Captain
+nd    x 511    y 1101    w 512    h 512 #Co Pilot
+
+# X-Plane 11 Toliss A339 Std Definition
+icao    A339
+studio    ToLiss
+acf A330-900_XP11_StdDef.acf
+fontsz    35
+bgalpha    0.3
+nd    x 511    y 1615    w 512    h 512 #Captain
+nd    x 511    y 1101    w 512    h 512 #Co Pilot
+
 # X-Plane 11 Toliss A340 Hi Definition
 icao	A346
 studio	ToLiss
@@ -335,24 +389,6 @@ nd	x 511	y 1101	w 512	h 512 #Co Pilot
 icao	A346
 studio	ToLiss
 acf A340-600_XP11_StdDef.acf
-fontsz	35
-bgalpha	0.3
-nd	x 511	y 1615	w 512	h 512 #Captain
-nd	x 511	y 1101	w 512	h 512 #Co Pilot
-
-# X-Plane 12 Toliss A340 Hi Definition
-icao	A346
-studio	ToLiss
-acf A340-600.acf
-fontsz	35
-bgalpha	0.3
-nd	x 511	y 1615	w 512	h 512 #Captain
-nd	x 511	y 1101	w 512	h 512 #Co Pilot
-
-# X-Plane 12 Toliss A340 Std Definition
-icao	A346
-studio	ToLiss
-acf A340-600_StdDef.acf
 fontsz	35
 bgalpha	0.3
 nd	x 511	y 1615	w 512	h 512 #Captain


### PR DESCRIPTION
Hi @olivierbutler,

I added the ND overlays for the ToLiss A330neo as provided in this [Livery Pack](https://forums.x-plane.org/index.php?/files/file/92878-toliss-a330neo-condor-fleet-pack-incl-cabin-13/).